### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/LurieDemo/c4110e5c-f303-48cf-abe2-97c6201a119c/a923113f-582e-4789-b4ce-e814bb1d09f5/_apis/work/boardbadge/3c96d64b-ae07-49fc-a607-d91aaa465f01)](https://dev.azure.com/LurieDemo/c4110e5c-f303-48cf-abe2-97c6201a119c/_boards/board/t/a923113f-582e-4789-b4ce-e814bb1d09f5/Microsoft.RequirementCategory)
 # luriedemo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#194](https://dev.azure.com/LurieDemo/c4110e5c-f303-48cf-abe2-97c6201a119c/_workitems/edit/194). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.